### PR TITLE
fix: more logs in `maestro`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7628,6 +7628,7 @@ dependencies = [
  "rand 0.9.2",
  "redis",
  "reqwest",
+ "serde",
  "serde_json",
  "shared",
  "test-utils",

--- a/synd-maestro/Cargo.toml
+++ b/synd-maestro/Cargo.toml
@@ -33,6 +33,7 @@ humantime         = { workspace = true }
 jsonrpsee         = { workspace = true, features = ["full"] }
 prometheus-client = { workspace = true }
 redis             = { workspace = true, features = ["connection-manager", "streams", "tokio-comp"] }
+serde             = { workspace = true }
 serde_json        = { workspace = true }
 shared            = { workspace = true }
 test-utils        = { workspace = true }

--- a/synd-maestro/src/lib.rs
+++ b/synd-maestro/src/lib.rs
@@ -7,4 +7,5 @@ pub mod layers;
 pub mod maestro;
 pub mod metrics;
 pub mod server;
+pub mod types;
 pub mod valkey;

--- a/synd-maestro/src/maestro.rs
+++ b/synd-maestro/src/maestro.rs
@@ -147,19 +147,20 @@ impl MaestroService {
                 let tx = decode_transaction(&Bytes::from(raw_tx)).unwrap();
                 #[allow(clippy::unwrap_used)]
                 let signer = check_signature(&tx).unwrap();
+                let chain_id = tx.chain_id().unwrap_or_default();
 
                 match provider.get_transaction_count(signer).await {
                     Ok(nonce) => {
                         if nonce <= tx.nonce() {
-                            warn!(%tx_hash, "Valid transaction is not finalized, resubmitting");
+                            warn!(%tx_hash, %chain_id, "Valid transaction is not finalized, resubmitting");
                             metrics.increment_resubmitted_transactions(1);
                             return CheckFinalizationResult::ReSubmit;
                         }
-                        warn!(%tx_hash, "Transaction is not finalized, but nonce is not valid anymore, done");
+                        warn!(%tx_hash, %chain_id, "Transaction is not finalized, but nonce is not valid anymore, done");
                         CheckFinalizationResult::Done
                     }
                     Err(err) => {
-                        error!(%tx_hash, %err, "Failed to query RPC for nonce during finalization check");
+                        error!(%tx_hash, %chain_id, %err, "Failed to query RPC for nonce during finalization check");
                         CheckFinalizationResult::Done
                     }
                 }

--- a/synd-maestro/src/maestro.rs
+++ b/synd-maestro/src/maestro.rs
@@ -266,7 +266,7 @@ impl MaestroService {
         let chain_wallet_lock = self.get_chain_wallet_lock(chain_id, signer_wallet).await;
         let _guard = chain_wallet_lock.lock().await;
         trace!(chain_id, %signer_wallet, "got lock");
-        debug!(tx_summary = %fmt_tx_envelope_for_logging(&tx, &signer_wallet), "Transaction summary");
+        debug!(tx_summary = %fmt_tx_envelope_for_logging(tx, &signer_wallet), "Transaction summary");
 
         let expected_nonce =
             self.get_expected_nonce_and_validate(signer_wallet, chain_id, tx_nonce).await?;

--- a/synd-maestro/src/maestro.rs
+++ b/synd-maestro/src/maestro.rs
@@ -13,6 +13,7 @@ use crate::{
         WaitingTransactionError::{FailedToDecode, FailedToEnqueue},
     },
     metrics::MaestroMetrics,
+    types::fmt_tx_envelope_for_logging,
     valkey::{
         keys::wallet_nonce::{chain_wallet_nonce_key, ChainWalletNonceKey},
         models::{
@@ -148,19 +149,20 @@ impl MaestroService {
                 #[allow(clippy::unwrap_used)]
                 let signer = check_signature(&tx).unwrap();
                 let chain_id = tx.chain_id().unwrap_or_default();
+                let tx_str = fmt_tx_envelope_for_logging(&tx, &signer);
 
                 match provider.get_transaction_count(signer).await {
                     Ok(nonce) => {
                         if nonce <= tx.nonce() {
-                            warn!(%tx_hash, %chain_id, "Valid transaction is not finalized, resubmitting");
+                            warn!(%tx_hash, %chain_id, tx=tx_str, "Valid transaction is not finalized, resubmitting");
                             metrics.increment_resubmitted_transactions(1);
                             return CheckFinalizationResult::ReSubmit;
                         }
-                        warn!(%tx_hash, %chain_id, "Transaction is not finalized, but nonce is not valid anymore, done");
+                        warn!(%tx_hash, %chain_id, tx=tx_str, "Transaction is not finalized, but nonce is not valid anymore, done");
                         CheckFinalizationResult::Done
                     }
                     Err(err) => {
-                        error!(%tx_hash, %chain_id, %err, "Failed to query RPC for nonce during finalization check");
+                        error!(%tx_hash, %chain_id, tx=tx_str, %err, "Failed to query RPC for nonce during finalization check");
                         CheckFinalizationResult::Done
                     }
                 }
@@ -250,42 +252,45 @@ impl MaestroService {
         fields(
             otel.kind = ?SpanKind::Producer,
             tx_hash = format!("0x{}", hex::encode(keccak256(raw_tx.as_ref()))),
-            chain_id, wallet = %wallet, tx_nonce
+            chain_id, signer_wallet = %signer_wallet, tx_nonce
         )
     )]
     pub async fn handle_transaction(
         self: &Arc<Self>,
         raw_tx: Bytes,
         tx: &TxEnvelope,
-        wallet: Address,
+        signer_wallet: Address,
         chain_id: ChainId,
         tx_nonce: u64,
     ) -> Result<(), MaestroRpcError> {
-        let chain_wallet_lock = self.get_chain_wallet_lock(chain_id, wallet).await;
+        let chain_wallet_lock = self.get_chain_wallet_lock(chain_id, signer_wallet).await;
         let _guard = chain_wallet_lock.lock().await;
-        trace!(chain_id, %wallet, "got lock");
+        trace!(chain_id, %signer_wallet, "got lock");
+        debug!(tx_summary = %fmt_tx_envelope_for_logging(&tx, &signer_wallet), "Transaction summary");
 
         let expected_nonce =
-            self.get_expected_nonce_and_validate(wallet, chain_id, tx_nonce).await?;
+            self.get_expected_nonce_and_validate(signer_wallet, chain_id, tx_nonce).await?;
 
         match tx_nonce.cmp(&expected_nonce) {
             Ordering::Equal => {
                 if !self.config.skip_balance_check {
                     // TODO(SEQ-964): Remove lines below once we have tracing
                     let tx_hash_str = format!("0x{}", hex::encode(tx.hash()));
-                    trace!(%tx_hash_str, %tx_nonce, sender_wallet=%wallet, %chain_id, "Checking sender wallet balance");
+                    trace!(%tx_hash_str, %tx_nonce, sender_wallet=%signer_wallet, %chain_id, "Checking sender wallet balance");
                     let sender_balance_eth = format!(
                         "{} ETH units",
-                        format_ether(self.check_sender_wallet_balance(tx, chain_id, wallet).await?)
+                        format_ether(
+                            self.check_sender_wallet_balance(tx, chain_id, signer_wallet).await?
+                        )
                     );
-                    trace!(%tx_hash_str, %tx_nonce, sender_wallet=%wallet, %sender_balance_eth, %chain_id, "Sender wallet balance is sufficient");
+                    trace!(%tx_hash_str, %tx_nonce, sender_wallet=%signer_wallet, %sender_balance_eth, %chain_id, "Sender wallet balance is sufficient");
                 }
 
                 // 1. update the cache with nonce + 1. Quit if this fails
-                let new_nonce = self.increment_wallet_nonce(chain_id, wallet, tx_nonce, tx_nonce+1).await.
+                let new_nonce = self.increment_wallet_nonce(chain_id, signer_wallet, tx_nonce, tx_nonce+1).await.
                     map_err(|e| {
                         let rejection = NonceTooLow(tx_nonce+1 , tx_nonce);
-                        debug!(%e, %chain_id, %wallet, %expected_nonce, %tx_nonce, "failed to increment wallet nonce");
+                        debug!(%e, %chain_id, %signer_wallet, %expected_nonce, %tx_nonce, "failed to increment wallet nonce");
                         JsonRpcError(TransactionRejected(rejection))
                     }
                     )?;
@@ -299,7 +304,11 @@ impl MaestroService {
                 let _handle = tokio::spawn(
                     async move {
                         service_clone
-                            .check_for_and_enqueue_waiting_transactions(chain_id, wallet, new_nonce)
+                            .check_for_and_enqueue_waiting_transactions(
+                                chain_id,
+                                signer_wallet,
+                                new_nonce,
+                            )
                             .await
                     }
                     .in_current_span(),
@@ -312,8 +321,14 @@ impl MaestroService {
             }
             Ordering::Greater => {
                 debug!(tx_hash = format!("0x{}", hex::encode(tx.hash())), %chain_id, "Caching waiting transaction");
-                self.cache_waiting_transaction(chain_id, wallet, tx_nonce, raw_tx, tx.hash())
-                    .await?;
+                self.cache_waiting_transaction(
+                    chain_id,
+                    signer_wallet,
+                    tx_nonce,
+                    raw_tx,
+                    tx.hash(),
+                )
+                .await?;
                 self.metrics.increment_waiting_transactions(1);
             }
         }
@@ -405,7 +420,7 @@ impl MaestroService {
                 debug!(%e, %wallet_address, %chain_id, %cached_wallet_nonce, %tx_nonce, max_nonce_buffer = ?self.config.max_nonce_buffer,
                             "Nonce buffer exceeded, rejecting transaction");
             })?;
-            return Ok(cached_wallet_nonce)
+            return Ok(cached_wallet_nonce);
         }
 
         trace!(%wallet_address, %chain_id, "No cached nonce found, fetching from RPC");
@@ -902,7 +917,7 @@ const fn check_tx_nonce_within_buffer(
 ) -> Result<(), MaestroRpcError> {
     if let Some(nonce_gap) = tx_nonce.checked_sub(cached_wallet_nonce) {
         if nonce_gap > max_nonce_buffer {
-            return Err(JsonRpcError(TransactionRejected(NonceBufferExceeded)))
+            return Err(JsonRpcError(TransactionRejected(NonceBufferExceeded)));
         }
     }
     Ok(())

--- a/synd-maestro/src/types.rs
+++ b/synd-maestro/src/types.rs
@@ -1,0 +1,230 @@
+//! Types used by the `synd-maestro` package.
+
+use alloy::{
+    consensus::{Transaction, TxEnvelope},
+    hex,
+    primitives::Address,
+};
+use serde::{Deserialize, Serialize};
+
+/// Structured representation of a TxEnvelope for logging
+#[derive(Debug, Serialize, Deserialize)]
+struct TxEnvelopeLog {
+    hash: String,
+    signer_address: String,
+    tx_type: String,
+    chain_id: u64,
+    nonce: u64,
+    to: String,
+    gas_limit: u64,
+    max_fee_per_gas: u128,
+    max_priority_fee_per_gas: u128,
+    gas_price: u128,
+    value: String, // Using string to handle U256 properly
+    input_len: usize,
+}
+
+/// Formats a `TxEnvelope` for human-friendly logging as JSON.
+pub fn fmt_tx_envelope_for_logging(tx: &TxEnvelope, signer: &Address) -> String {
+    let tx_log = TxEnvelopeLog {
+        hash: format!("0x{}", hex::encode(tx.hash())),
+        signer_address: signer.to_string(),
+        tx_type: match tx {
+            TxEnvelope::Legacy(_) => "legacy",
+            TxEnvelope::Eip2930(_) => "eip2930",
+            TxEnvelope::Eip1559(_) => "eip1559",
+            TxEnvelope::Eip4844(_) => "eip4844",
+            _ => "unknown",
+        }
+        .to_string(),
+        chain_id: tx.chain_id().unwrap_or_default(),
+        nonce: tx.nonce(),
+        to: match tx.to() {
+            Some(to) => format!("0x{}", hex::encode(to)),
+            None => "none".to_string(),
+        },
+        gas_limit: tx.gas_limit(),
+        max_fee_per_gas: tx.max_fee_per_gas(),
+        max_priority_fee_per_gas: tx.max_priority_fee_per_gas().unwrap_or_default(),
+        gas_price: tx.gas_price().unwrap_or_default(),
+        value: tx.value().to_string(), // Convert U256 to string for JSON
+        input_len: tx.input().len(),
+    };
+
+    // Serialize to JSON string
+    serde_json::to_string(&tx_log).unwrap_or_else(|e| {
+        format!("failed to serialize TxEnvelopeLog to JSON - this should never happen! {e}")
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloy::{
+        network::{EthereumWallet, TransactionBuilder},
+        primitives::{utils::parse_ether, Address, Bytes, U256},
+        rpc::types::TransactionRequest,
+        signers::local::PrivateKeySigner,
+    };
+    use serde_json::Value;
+    use shared::tx_validation::{check_signature, decode_transaction};
+    use test_utils::transaction::create_legacy_transaction;
+    use tracing::info;
+
+    #[tokio::test]
+    async fn test_fmt_tx_envelope_for_logging_json_structure() {
+        // Create a fully populated EIP-1559 transaction
+        let signer = PrivateKeySigner::random();
+        let wallet = EthereumWallet::from(signer);
+
+        let chain_id = 1u64;
+        let nonce = 100u64;
+        let to_address = Address::from([0x12; 20]);
+        let value = parse_ether("1.5").unwrap();
+        let gas_limit = 21000u64;
+        let max_fee_per_gas = 50_000_000_000u128; // 50 gwei
+        let max_priority_fee_per_gas = 2_000_000_000u128; // 2 gwei
+        let input_data = Bytes::from(vec![0x01, 0x02, 0x03, 0x04, 0x05]);
+
+        let tx = TransactionRequest::default()
+            .with_to(to_address)
+            .with_value(value)
+            .with_nonce(nonce)
+            .with_gas_limit(gas_limit)
+            .with_max_fee_per_gas(max_fee_per_gas)
+            .with_max_priority_fee_per_gas(max_priority_fee_per_gas)
+            .with_chain_id(chain_id)
+            .with_input(input_data.clone())
+            .build(&wallet)
+            .await
+            .expect("Failed to build transaction");
+
+        let signer_address = wallet.default_signer().address();
+        let formatted = fmt_tx_envelope_for_logging(&tx, &signer_address);
+
+        // Parse as JSON and verify structure
+        let json: Value = serde_json::from_str(&formatted).expect("Should be valid JSON");
+
+        // Verify all expected fields are present
+        assert!(json.get("hash").is_some());
+        assert!(json.get("signer_address").is_some());
+        assert!(json.get("tx_type").is_some());
+        assert!(json.get("chain_id").is_some());
+        assert!(json.get("nonce").is_some());
+        assert!(json.get("to").is_some());
+        assert!(json.get("gas_limit").is_some());
+        assert!(json.get("max_fee_per_gas").is_some());
+        assert!(json.get("max_priority_fee_per_gas").is_some());
+        assert!(json.get("gas_price").is_some());
+        assert!(json.get("value").is_some());
+        assert!(json.get("input_len").is_some());
+
+        // Verify specific values
+        assert_eq!(json["tx_type"], "eip1559");
+        assert_eq!(json["chain_id"], chain_id);
+        assert_eq!(json["nonce"], nonce);
+        assert_eq!(json["to"], format!("0x{}", hex::encode(to_address)));
+        assert_eq!(json["gas_limit"], gas_limit);
+        assert_eq!(json["max_fee_per_gas"].to_string(), max_fee_per_gas.to_string());
+        assert_eq!(
+            json["max_priority_fee_per_gas"].to_string(),
+            max_priority_fee_per_gas.to_string()
+        );
+        assert_eq!(json["value"], value.to_string());
+        assert_eq!(json["input_len"], input_data.len());
+        assert_eq!(json["signer_address"], signer_address.to_string());
+
+        // Verify hash format
+        let hash_str = json["hash"].as_str().unwrap();
+        assert!(hash_str.starts_with("0x"));
+        assert_eq!(hash_str.len(), 66); // 0x + 64 hex chars
+        info!(tx_log=%fmt_tx_envelope_for_logging(&tx, &signer_address), "sample log");
+    }
+
+    #[tokio::test]
+    async fn test_fmt_tx_envelope_for_logging_with_legacy_transaction() {
+        let chain_id = 4u64;
+        let nonce = 42u64;
+        let raw_tx = create_legacy_transaction(chain_id, nonce);
+
+        let tx = decode_transaction(&raw_tx).expect("Failed to decode transaction");
+        let signer = check_signature(&tx).expect("Failed to check signature");
+
+        let formatted = fmt_tx_envelope_for_logging(&tx, &signer);
+
+        // Verify it's valid JSON
+        let json: Value = serde_json::from_str(&formatted).expect("Should be valid JSON");
+
+        assert_eq!(json["tx_type"], "legacy");
+        assert_eq!(json["chain_id"], chain_id);
+        assert_eq!(json["nonce"], nonce);
+        assert!(json["hash"].as_str().unwrap().starts_with("0x"));
+        info!(tx_log=%fmt_tx_envelope_for_logging(&tx, &signer), "sample log");
+    }
+
+    #[tokio::test]
+    async fn test_fmt_tx_envelope_for_logging_contract_creation() {
+        let signer = PrivateKeySigner::random();
+        let wallet = EthereumWallet::from(signer);
+
+        // For contract creation, explicitly don't set a 'to' address
+        let tx = TransactionRequest::default()
+            .with_value(U256::ZERO)
+            .with_to(Address::ZERO)
+            .with_nonce(0)
+            .with_gas_limit(2_000_000u64)
+            .with_max_fee_per_gas(20_000_000_000u128)
+            .with_max_priority_fee_per_gas(1_000_000_000u128)
+            .with_chain_id(1u64)
+            .with_input(Bytes::from(vec![0x60, 0x80, 0x60, 0x40, 0x52]))
+            .build(&wallet)
+            .await
+            .expect("Failed to build contract creation transaction");
+
+        let signer_address = wallet.default_signer().address();
+        let formatted = fmt_tx_envelope_for_logging(&tx, &signer_address);
+
+        let json: Value = serde_json::from_str(&formatted).expect("Should be valid JSON");
+
+        // Contract creation should have "none" as the to address
+        assert_eq!(json["to"], "0x0000000000000000000000000000000000000000");
+        assert_eq!(json["input_len"], 5);
+        info!(tx_log=%fmt_tx_envelope_for_logging(&tx, &signer_address), "sample log");
+    }
+
+    #[tokio::test]
+    async fn test_fmt_tx_envelope_for_logging_deserializable() {
+        let signer = PrivateKeySigner::random();
+        let wallet = EthereumWallet::from(signer);
+
+        let tx = TransactionRequest::default()
+            .with_to(Address::ZERO)
+            .with_value(parse_ether("2.5").unwrap())
+            .with_nonce(99)
+            .with_gas_limit(30000)
+            .with_max_fee_per_gas(15_000_000_000u128)
+            .with_max_priority_fee_per_gas(1_500_000_000u128)
+            .with_chain_id(42u64)
+            .build(&wallet)
+            .await
+            .expect("Failed to build transaction");
+
+        let signer_address = wallet.default_signer().address();
+        let formatted = fmt_tx_envelope_for_logging(&tx, &signer_address);
+
+        // Deserialize back to our struct to verify it's complete
+        let tx_log: TxEnvelopeLog =
+            serde_json::from_str(&formatted).expect("Should deserialize back to TxEnvelopeLog");
+
+        assert_eq!(tx_log.tx_type, "eip1559");
+        assert_eq!(tx_log.chain_id, 42);
+        assert_eq!(tx_log.nonce, 99);
+        assert_eq!(tx_log.gas_limit, 30000);
+        assert_eq!(tx_log.max_fee_per_gas, 15_000_000_000u128);
+        assert_eq!(tx_log.max_priority_fee_per_gas, 1_500_000_000u128);
+        assert_eq!(tx_log.value, parse_ether("2.5").unwrap().to_string());
+        assert_eq!(tx_log.to, "0x0000000000000000000000000000000000000000");
+        assert_eq!(tx_log.signer_address, signer_address.to_string());
+        info!(tx_log=%fmt_tx_envelope_for_logging(&tx, &signer_address), "sample log");
+    }
+}

--- a/synd-maestro/src/types.rs
+++ b/synd-maestro/src/types.rs
@@ -164,7 +164,6 @@ mod tests {
         let signer = PrivateKeySigner::random();
         let wallet = EthereumWallet::from(signer);
 
-        // For contract creation, explicitly don't set a 'to' address
         let tx = TransactionRequest::default()
             .with_value(U256::ZERO)
             .with_to(Address::ZERO)

--- a/synd-maestro/src/types.rs
+++ b/synd-maestro/src/types.rs
@@ -7,7 +7,7 @@ use alloy::{
 };
 use serde::{Deserialize, Serialize};
 
-/// Structured representation of a TxEnvelope for logging
+/// Structured representation of a `TxEnvelope` for logging
 #[derive(Debug, Serialize, Deserialize)]
 struct TxEnvelopeLog {
     hash: String,
@@ -39,10 +39,7 @@ pub fn fmt_tx_envelope_for_logging(tx: &TxEnvelope, signer: &Address) -> String 
         .to_string(),
         chain_id: tx.chain_id().unwrap_or_default(),
         nonce: tx.nonce(),
-        to: match tx.to() {
-            Some(to) => format!("0x{}", hex::encode(to)),
-            None => "none".to_string(),
-        },
+        to: tx.to().map_or_else(|| "none".to_string(), |to| format!("0x{}", hex::encode(to))),
         gas_limit: tx.gas_limit(),
         max_fee_per_gas: tx.max_fee_per_gas(),
         max_priority_fee_per_gas: tx.max_priority_fee_per_gas().unwrap_or_default(),

--- a/synd-translator/crates/synd-block-builder/src/appchains/shared/sequencing_transaction_parser.rs
+++ b/synd-translator/crates/synd-block-builder/src/appchains/shared/sequencing_transaction_parser.rs
@@ -185,7 +185,7 @@ impl SequencingTransactionParser {
                 if data.len() > MAX_L2_MESSAGE_SIZE {
                     return Err(SequencingParserError::InvalidTxData(
                         "dropping tx greater than the max l2 message size".to_string(),
-                    ))
+                    ));
                 }
                 // TODO(SEQ-1370): compute tx hash for unsigned txs
                 Ok(vec![(data.clone(), Default::default())])


### PR DESCRIPTION
### Ticket
- **Related Linear Ticket:** n/a, from INC-24

### What does this PR do?
- **Summary:** 
  - Adds detailed logging for resubmitted transactions to better understand why they're being resubmitted

### Breaking changes?
- **No, just logs**

### Metrics changes?
- **No** 

### How can this PR be tested?
- Wrote tests with sample logging