### PR TITLE
Tracing-related fixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1776,7 +1776,7 @@ dependencies = [
  "bitflags",
  "cexpr",
  "clang-sys",
- "itertools 0.13.0",
+ "itertools 0.10.5",
  "log",
  "prettyplease",
  "proc-macro2",
@@ -1796,7 +1796,7 @@ dependencies = [
  "bitflags",
  "cexpr",
  "clang-sys",
- "itertools 0.13.0",
+ "itertools 0.10.5",
  "log",
  "prettyplease",
  "proc-macro2",
@@ -2242,7 +2242,7 @@ version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fde0e0ec90c9dfb3b4b1a0891a7dcd0e2bffde2f7efed5fe7c9bb00e5bfb915e"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -3759,7 +3759,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.0",
+ "socket2 0.5.10",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -4349,7 +4349,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07033963ba89ebaf1584d767badaa2e8fcec21aedea6b8c0346d487d49c28667"
 dependencies = [
  "cfg-if",
- "windows-targets 0.53.3",
+ "windows-targets 0.48.5",
 ]
 
 [[package]]
@@ -4876,9 +4876,9 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry"
-version = "0.30.0"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aaf416e4cb72756655126f7dd7bb0af49c674f4c1b9903e80c009e0c37e552e6"
+checksum = "b84bcd6ae87133e903af7ef497404dda70c60d0ea14895fc8a5e6722754fc2a0"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -4890,9 +4890,9 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry-http"
-version = "0.30.0"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50f6639e842a97dbea8886e3439710ae463120091e2e064518ba8e716e6ac36d"
+checksum = "d7a6d09a73194e6b66df7c8f1b680f156d916a1a942abf2de06823dd02b7855d"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4903,16 +4903,16 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry-otlp"
-version = "0.30.0"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbee664a43e07615731afc539ca60c6d9f1a9425e25ca09c57bc36c87c55852b"
+checksum = "7a2366db2dca4d2ad033cad11e6ee42844fd727007af5ad04a1730f4cb8163bf"
 dependencies = [
  "http 1.3.1",
  "opentelemetry",
  "opentelemetry-http",
  "opentelemetry-proto",
  "opentelemetry_sdk",
- "prost",
+ "prost 0.14.1",
  "reqwest",
  "thiserror 2.0.16",
  "tracing",
@@ -4920,27 +4920,28 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry-proto"
-version = "0.30.0"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e046fd7660710fe5a05e8748e70d9058dc15c94ba914e7c4faa7c728f0e8ddc"
+checksum = "a7175df06de5eaee9909d4805a3d07e28bb752c34cab57fa9cff549da596b30f"
 dependencies = [
  "opentelemetry",
  "opentelemetry_sdk",
- "prost",
- "tonic 0.13.1",
+ "prost 0.14.1",
+ "tonic 0.14.2",
+ "tonic-prost",
 ]
 
 [[package]]
 name = "opentelemetry-semantic-conventions"
-version = "0.30.0"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83d059a296a47436748557a353c5e6c5705b9470ef6c95cfc52c21a8814ddac2"
+checksum = "e62e29dfe041afb8ed2a6c9737ab57db4907285d999ef8ad3a59092a36bdc846"
 
 [[package]]
 name = "opentelemetry-stdout"
-version = "0.30.0"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "447191061af41c3943e082ea359ab8b64ff27d6d34d30d327df309ddef1eef6f"
+checksum = "bc8887887e169414f637b18751487cce4e095be787d23fad13c454e2fb1b3811"
 dependencies = [
  "chrono",
  "opentelemetry",
@@ -4949,9 +4950,9 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry_sdk"
-version = "0.30.0"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11f644aa9e5e31d11896e024305d7e3c98a88884d9f8919dbf37a9991bc47a4b"
+checksum = "e14ae4f5991976fd48df6d843de219ca6d31b01daaab2dad5af2badeded372bd"
 dependencies = [
  "futures-channel",
  "futures-executor",
@@ -4959,7 +4960,6 @@ dependencies = [
  "opentelemetry",
  "percent-encoding",
  "rand 0.9.2",
- "serde_json",
  "thiserror 2.0.16",
 ]
 
@@ -5593,7 +5593,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2796faa41db3ec313a31f7624d9286acf277b52de526150b7e69f3debf891ee5"
 dependencies = [
  "bytes",
- "prost-derive",
+ "prost-derive 0.13.5",
+]
+
+[[package]]
+name = "prost"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7231bd9b3d3d33c86b58adbac74b5ec0ad9f496b19d22801d773636feaa95f3d"
+dependencies = [
+ "bytes",
+ "prost-derive 0.14.1",
 ]
 
 [[package]]
@@ -5603,7 +5613,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.10.5",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9120690fafc389a67ba3803df527d0ec9cbbc9cc45e4cc20b332996dfb672425"
+dependencies = [
+ "anyhow",
+ "itertools 0.10.5",
  "proc-macro2",
  "quote",
  "syn 2.0.106",
@@ -5648,7 +5671,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash 2.1.1",
  "rustls 0.23.31",
- "socket2 0.6.0",
+ "socket2 0.5.10",
  "thiserror 2.0.16",
  "tokio",
  "tracing",
@@ -5685,7 +5708,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.0",
+ "socket2 0.5.10",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -7035,7 +7058,7 @@ checksum = "a04cfd497bcb85d52eccd3718ddc8d88f17bfc4aefa288b41d1b0b21a065f3fc"
 dependencies = [
  "bincode 1.3.3",
  "ctrlc",
- "prost",
+ "prost 0.13.5",
  "serde",
  "sp1-core-machine",
  "sp1-prover",
@@ -7317,7 +7340,7 @@ dependencies = [
  "p3-baby-bear",
  "p3-field",
  "p3-fri",
- "prost",
+ "prost 0.13.5",
  "reqwest",
  "reqwest-middleware",
  "rustls 0.23.31",
@@ -8231,7 +8254,7 @@ dependencies = [
  "hyper-util",
  "percent-encoding",
  "pin-project",
- "prost",
+ "prost 0.13.5",
  "rustls-native-certs 0.8.1",
  "rustls-pemfile 2.2.0",
  "socket2 0.5.10",
@@ -8246,9 +8269,9 @@ dependencies = [
 
 [[package]]
 name = "tonic"
-version = "0.13.1"
+version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e581ba15a835f4d9ea06c55ab1bd4dce26fc53752c69a04aac00703bfb49ba9"
+checksum = "eb7613188ce9f7df5bfe185db26c5814347d110db17920415cf2fbcad85e7203"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -8258,11 +8281,22 @@ dependencies = [
  "http-body-util",
  "percent-encoding",
  "pin-project",
- "prost",
+ "sync_wrapper",
  "tokio-stream",
  "tower-layer",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "tonic-prost"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66bd50ad6ce1252d87ef024b3d64fe4c3cf54a86fb9ef4c631fdd0ded7aeaa67"
+dependencies = [
+ "bytes",
+ "prost 0.14.1",
+ "tonic 0.14.2",
 ]
 
 [[package]]
@@ -8402,15 +8436,16 @@ dependencies = [
 
 [[package]]
 name = "tracing-opentelemetry"
-version = "0.31.0"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddcf5959f39507d0d04d6413119c04f33b623f4f951ebcbdddddfad2d0623a9c"
+checksum = "1e6e5658463dd88089aba75c7791e1d3120633b1bfde22478b28f625a9bb1b8e"
 dependencies = [
  "js-sys",
- "once_cell",
  "opentelemetry",
  "opentelemetry_sdk",
+ "rustversion",
  "smallvec",
+ "thiserror 2.0.16",
  "tracing",
  "tracing-core",
  "tracing-log",
@@ -8486,7 +8521,7 @@ dependencies = [
  "http 1.3.1",
  "http-body-util",
  "hyper 1.7.0",
- "prost",
+ "prost 0.13.5",
  "reqwest",
  "serde",
  "serde_json",
@@ -8882,7 +8917,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -89,11 +89,11 @@ http-body-util                     = "0.1"
 humantime                          = "2.1.0"
 hyper                              = { version = "1.5.2" }
 jsonrpsee                          = "0.26.0"
-opentelemetry                      = "0.30.0"
-opentelemetry-otlp                 = "0.30.0"
-opentelemetry-semantic-conventions = { version = "0.30.0", features = ["semconv_experimental"] }
-opentelemetry-stdout               = "0.30.0"
-opentelemetry_sdk                  = { version = "0.30.0", features = ["trace"] }
+opentelemetry                      = "0.31.0"
+opentelemetry-otlp                 = "0.31.0"
+opentelemetry-semantic-conventions = { version = "0.31.0", features = ["semconv_experimental"] }
+opentelemetry-stdout               = "0.31.0"
+opentelemetry_sdk                  = { version = "0.31.0", features = ["trace"] }
 p384                               = "0.13.1"                                                    # NOTE: this lib is NOT AUDITED
 pin-project-lite                   = "0.2.16"
 prometheus-client                  = { version = "0.23.1" }
@@ -119,7 +119,7 @@ tower                              = { version = "0.5.2" }
 tower-layer                        = { version = "0.3.3" }
 tower-service                      = { version = "0.3.3" }
 tracing                            = "0.1.41"
-tracing-opentelemetry              = "0.31.0"
+tracing-opentelemetry              = "0.32.0"
 tracing-subscriber                 = "0.3.20"
 url                                = { version = "2.5.4" }
 wiremock                           = "0.6.3"

--- a/shared/src/tracing.rs
+++ b/shared/src/tracing.rs
@@ -101,7 +101,9 @@ pub fn setup_global_tracing(config: ServiceTracingConfig) -> Result<OtelGuard, E
         .with_default_directive(filter::LevelFilter::INFO.into())
         .from_env()?
         // disable spammy and unconnected jsonrpsee_server `connection` spans
-        .add_directive("jsonrpsee_server=off".parse()?);
+        .add_directive("jsonrpsee_server=off".parse()?)
+        // disable internal opentelemetry spans that don't adhere to RUST_LOG directives
+        .add_directive("opentelemetry_sdk=off".parse()?);
 
     let disable_json = std::env::var("RUST_LOG_DISABLE_JSON").is_ok();
     let disable_telemetry = std::env::var("RUST_LOG_DISABLE_TELEMETRY").is_ok();

--- a/shared/src/tracing.rs
+++ b/shared/src/tracing.rs
@@ -167,7 +167,7 @@ pub fn extract_tracing_context(extensions: &Extensions) -> Option<()> {
     carrier.insert("traceparent".to_string(), traceparent.replace("-03", "-01"));
     let parent_context =
         otel_global::get_text_map_propagator(|propagator| propagator.extract(&carrier));
-    Span::current().set_parent(parent_context);
+    Span::current().set_parent(parent_context).expect("failed to set parent context");
     Some(())
 }
 

--- a/shared/src/tracing.rs
+++ b/shared/src/tracing.rs
@@ -106,7 +106,7 @@ pub fn setup_global_tracing(config: ServiceTracingConfig) -> Result<OtelGuard, E
         .add_directive("opentelemetry_sdk=off".parse()?);
 
     let disable_json = std::env::var("RUST_LOG_DISABLE_JSON").is_ok();
-    let disable_telemetry = std::env::var("RUST_LOG_DISABLE_TELEMETRY").is_ok();
+    let enable_telemetry = std::env::var("RUST_LOG_ENABLE_TELEMETRY").is_ok();
 
     let fmt_layer = tracing_subscriber::fmt::layer()
         // include codepath origin of log
@@ -115,11 +115,11 @@ pub fn setup_global_tracing(config: ServiceTracingConfig) -> Result<OtelGuard, E
 
     let tracing_subscriber = tracing_subscriber::registry().with(env_filter);
 
-    match (disable_telemetry, disable_json) {
-        (true, true) => tracing_subscriber.with(fmt_layer).try_init(),
-        (true, false) => tracing_subscriber.with(fmt_layer.json()).try_init(),
-        (false, true) => tracing_subscriber.with(OpenTelemetryLayer::new(tracer)).try_init(),
-        (false, false) => tracing_subscriber
+    match (enable_telemetry, disable_json) {
+        (false, true) => tracing_subscriber.with(fmt_layer).try_init(),
+        (false, false) => tracing_subscriber.with(fmt_layer.json()).try_init(),
+        (true, true) => tracing_subscriber.with(OpenTelemetryLayer::new(tracer)).try_init(),
+        (true, false) => tracing_subscriber
             .with(fmt_layer.json())
             .with(OpenTelemetryLayer::new(tracer))
             .try_init(),


### PR DESCRIPTION

### Ticket
- **Related Linear Ticket:** [ENG-1506: Fix OTel tracing (respect env vars, log level)](https://linear.app/syndicate/issue/ENG-1506/fix-otel-tracing-respect-env-vars-log-level)

### What does this PR do?
- **Summary:** Fixes for [ENG-1506: Fix OTel tracing (respect env vars, log level)](https://linear.app/syndicate/issue/ENG-1506/fix-otel-tracing-respect-env-vars-log-level)
- **Key Changes:**
  - [x] **Disable opentelemetry_sdk logs**: those don't adhere to `RUST_LOG` (at all), so it's simpler to disable them altogether rather than kludge a solution; tracing misconfigurations are easy to find, and there's next to 0 chance of properly configured tracing setup failing later on
  - [x] **Make OTel opt-in rather than opt-out**: should help `test-framework` tests and similar environments
  - [x] **Update tracing+opentelemetry related crates**: did it to see if it influences the log-level behavior, but also contains some stability fixes
  
### Breaking changes?
- **No**

### Metrics changes?
- **No**, but is related

### How can this PR be tested?
- Tested locally
- Should be deployed and tested on a live chain